### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn repl(mut input: impl BufRead, mut output: impl Write) {
         let lexer = Lexer::new(&line);
 
         for (i, token) in lexer.enumerate() {
-            writeln!(output, "{:2.}) {:?}", i, token).expect("Cannot write token");
+            writeln!(output, "{:2}) {:?}", i, token).expect("Cannot write token");
         }
     }
 }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.